### PR TITLE
NAVI31 was not detected properly due to a typo.

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/device_description.h
+++ b/tensorflow/compiler/xla/stream_executor/device_description.h
@@ -181,7 +181,7 @@ class RocmComputeCapability {
         "gfx940",  // MI300
         "gfx941",  // MI300
         "gfx942",  // MI300
-        "gfx1030"  // Navi21
+        "gfx1030", // Navi21
         "gfx1100"  // Navi31
     };
   }


### PR DESCRIPTION
I was trying to compile the TensorFlow for my RX 7900XTX and found that a typo in device_description.h was preventing it from detecting the card properly. With this fix, TF now detects my graphics card.

I'm sure there are other issues that need to be addressed before 7900 series works properly. But I wanted to bring this to the developer's attention.

So far, I got a Stable Defusion (https://gist.github.com/BloodBlight/0d36b33d215056395f34db26fb419a63) and an LLM (https://blog.mlc.ai/2023/08/09/Making-AMD-GPUs-competitive-for-LLM-inference)  working on my 7900 and want to get FT working as well. It seems AMD is getting close to supporting all the popular ML models soon.